### PR TITLE
Migrate primitives to current Base UI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "rajaniraiyn.dev",
       "dependencies": {
-        "@base-ui-components/react": "^1.0.0-beta.4",
+        "@base-ui/react": "1.6.0",
         "@tanstack/react-router": "1.170.16",
         "canvas-confetti": "1.9.4",
         "class-variance-authority": "^0.7.1",
@@ -78,7 +78,7 @@
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
 
-    "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
 
@@ -86,9 +86,9 @@
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
-    "@base-ui-components/react": ["@base-ui-components/react@1.0.0-beta.4", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@base-ui-components/utils": "0.1.2", "@floating-ui/react-dom": "^2.1.6", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "tabbable": "^6.2.0", "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-sPYKj26gbFHD2ZsrMYqQshXnMuomBodzPn+d0dDxWieTj232XCQ9QGt9fU9l5SDGC9hi8s24lDlg9FXPSI7T8A=="],
+    "@base-ui/react": ["@base-ui/react@1.6.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.3.1", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw=="],
 
-    "@base-ui-components/utils": ["@base-ui-components/utils@0.1.2", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-aEitDGpMsYO2qnSpYOwZNykn9Rzn2ioyEVk2fyDRH7t+TIHVKpp9CeV7SPTq43M9mMSDxQ+7UeZJVkrj2dCVIQ=="],
+    "@base-ui/utils": ["@base-ui/utils@0.3.1", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg=="],
 
     "@cacheable/memoize": ["@cacheable/memoize@2.0.3", "", { "dependencies": { "@cacheable/utils": "^2.0.3" } }, "sha512-hl9wfQgpiydhQEIv7fkjEzTGE+tcosCXLKFDO707wYJ/78FVOlowb36djex5GdbSyeHnG62pomYLMuV/OT8Pbw=="],
 
@@ -120,13 +120,13 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
-    "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
-    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
 
-    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.6", "", { "dependencies": { "@floating-ui/dom": "^1.7.4" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw=="],
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
-    "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -578,7 +578,7 @@
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
-    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
+    "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -603,8 +603,6 @@
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
-    "tabbable": ["tabbable@6.2.0", "", {}, "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@base-ui-components/react": "^1.0.0-beta.4",
+    "@base-ui/react": "1.6.0",
     "@tanstack/react-router": "1.170.16",
     "canvas-confetti": "1.9.4",
     "class-variance-authority": "^0.7.1",

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,4 +1,4 @@
-import { Accordion as AccordionPrimitive } from "@base-ui-components/react/accordion"
+import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion"
 import { ChevronDownIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,4 +1,4 @@
-import { Avatar as AvatarPrimitive } from "@base-ui-components/react/avatar"
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/badge-variants.ts
+++ b/src/components/ui/badge-variants.ts
@@ -1,0 +1,33 @@
+import { cva } from "class-variance-authority"
+
+export const badgeVariants = cva(
+  "relative inline-flex shrink-0 items-center justify-center gap-1 rounded-sm border border-transparent font-medium whitespace-nowrap transition-shadow outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3 [button,a&]:cursor-pointer [button,a&]:pointer-coarse:after:absolute [button,a&]:pointer-coarse:after:size-full [button,a&]:pointer-coarse:after:min-h-11 [button,a&]:pointer-coarse:after:min-w-11",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground [button,a&]:hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white [button,a&]:hover:bg-destructive/90",
+        outline:
+          "border-border bg-transparent dark:bg-input/32 [button,a&]:hover:bg-accent/50 dark:[button,a&]:hover:bg-input/48",
+        secondary:
+          "bg-secondary text-secondary-foreground [button,a&]:hover:bg-secondary/90",
+        info: "bg-info/8 text-info-foreground dark:bg-info/16",
+        success: "bg-success/8 text-success-foreground dark:bg-success/16",
+        warning: "bg-warning/8 text-warning-foreground dark:bg-warning/16",
+        error:
+          "bg-destructive/8 text-destructive-foreground dark:bg-destructive/16",
+      },
+      size: {
+        default: "px-[calc(--spacing(1)-1px)] text-xs",
+        sm: "rounded-[calc(var(--radius-sm)-2px)] px-[calc(--spacing(1)-1px)] text-[.625rem]",
+        lg: "px-[calc(--spacing(1.5)-1px)] text-sm",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,40 +1,9 @@
-import { mergeProps } from "@base-ui-components/react/merge-props"
-import { useRender } from "@base-ui-components/react/use-render"
-import { cva, type VariantProps } from "class-variance-authority"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
-
-const badgeVariants = cva(
-  "relative inline-flex shrink-0 items-center justify-center gap-1 rounded-sm border border-transparent font-medium whitespace-nowrap transition-shadow outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3 [button,a&]:cursor-pointer [button,a&]:pointer-coarse:after:absolute [button,a&]:pointer-coarse:after:size-full [button,a&]:pointer-coarse:after:min-h-11 [button,a&]:pointer-coarse:after:min-w-11",
-  {
-    variants: {
-      variant: {
-        default:
-          "bg-primary text-primary-foreground [button,a&]:hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white [button,a&]:hover:bg-destructive/90",
-        outline:
-          "border-border bg-transparent dark:bg-input/32 [button,a&]:hover:bg-accent/50 dark:[button,a&]:hover:bg-input/48",
-        secondary:
-          "bg-secondary text-secondary-foreground [button,a&]:hover:bg-secondary/90",
-        info: "bg-info/8 text-info-foreground dark:bg-info/16",
-        success: "bg-success/8 text-success-foreground dark:bg-success/16",
-        warning: "bg-warning/8 text-warning-foreground dark:bg-warning/16",
-        error:
-          "bg-destructive/8 text-destructive-foreground dark:bg-destructive/16",
-      },
-      size: {
-        default: "px-[calc(--spacing(1)-1px)] text-xs",
-        sm: "rounded-[calc(var(--radius-sm)-2px)] px-[calc(--spacing(1)-1px)] text-[.625rem]",
-        lg: "px-[calc(--spacing(1.5)-1px)] text-sm",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+import { badgeVariants } from "@/components/ui/badge-variants"
 
 interface BadgeProps extends useRender.ComponentProps<"span"> {
   variant?: VariantProps<typeof badgeVariants>["variant"]
@@ -54,4 +23,4 @@ function Badge({ className, variant, size, render, ...props }: BadgeProps) {
   })
 }
 
-export { Badge, badgeVariants }
+export { Badge }

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -1,0 +1,38 @@
+import { cva } from "class-variance-authority"
+
+export const buttonVariants = cva(
+  "relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-lg border bg-clip-padding text-sm font-medium whitespace-nowrap transition-shadow outline-none before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-primary bg-primary text-primary-foreground shadow-xs shadow-primary/24 not-disabled:inset-shadow-[0_1px_--theme(--color-white/16%)] hover:bg-primary/90 [&:is(:active,[data-pressed])]:inset-shadow-[0_1px_--theme(--color-black/8%)] [&:is(:disabled,:active,[data-pressed])]:shadow-none",
+        outline:
+          "border-border bg-background shadow-xs not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:bg-input/32 dark:not-in-data-[slot=group]:bg-clip-border dark:not-disabled:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/4%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/8%)] [&:is(:disabled,:active,[data-pressed])]:shadow-none [&:is(:hover,[data-pressed])]:bg-accent/50 dark:[&:is(:hover,[data-pressed])]:bg-input/64",
+        secondary:
+          "border-secondary bg-secondary text-secondary-foreground hover:bg-secondary/90 data-pressed:bg-secondary/90",
+        destructive:
+          "border-destructive bg-destructive text-white shadow-xs shadow-destructive/24 not-disabled:inset-shadow-[0_1px_--theme(--color-white/16%)] hover:bg-destructive/90 [&:is(:active,[data-pressed])]:inset-shadow-[0_1px_--theme(--color-black/8%)] [&:is(:disabled,:active,[data-pressed])]:shadow-none",
+        "destructive-outline":
+          "border-border bg-transparent text-destructive-foreground shadow-xs not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:bg-input/32 dark:not-in-data-[slot=group]:bg-clip-border dark:not-disabled:before:shadow-[0_-1px_--theme(--color-white/4%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/8%)] [&:is(:disabled,:active,[data-pressed])]:shadow-none [&:is(:hover,[data-pressed])]:border-destructive/32 [&:is(:hover,[data-pressed])]:bg-destructive/4",
+        ghost: "border-transparent hover:bg-accent data-pressed:bg-accent",
+        link: "border-transparent underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "min-h-8 px-[calc(--spacing(3)-1px)] py-[calc(--spacing(1.5)-1px)]",
+        xs: "min-h-6 gap-1 rounded-md px-[calc(--spacing(2)-1px)] py-[calc(--spacing(1)-1px)] text-xs before:rounded-[calc(var(--radius-md)-1px)] [&_svg:not([class*='size-'])]:size-3",
+        sm: "min-h-7 gap-1.5 px-[calc(--spacing(2.5)-1px)] py-[calc(--spacing(1)-1px)]",
+        lg: "min-h-9 px-[calc(--spacing(3.5)-1px)] py-[calc(--spacing(2)-1px)]",
+        xl: "min-h-10 px-[calc(--spacing(4)-1px)] py-[calc(--spacing(2)-1px)] text-base [&_svg:not([class*='size-'])]:size-4.5",
+        icon: "size-8",
+        "icon-sm": "size-7",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,46 +1,10 @@
 import * as React from "react"
-import { mergeProps } from "@base-ui-components/react/merge-props"
-import { useRender } from "@base-ui-components/react/use-render"
-import { cva, type VariantProps } from "class-variance-authority"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
-
-const buttonVariants = cva(
-  "relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-lg border bg-clip-padding text-sm font-medium whitespace-nowrap transition-shadow outline-none before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64 pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-  {
-    variants: {
-      variant: {
-        default:
-          "border-primary bg-primary text-primary-foreground shadow-xs shadow-primary/24 not-disabled:inset-shadow-[0_1px_--theme(--color-white/16%)] hover:bg-primary/90 [&:is(:active,[data-pressed])]:inset-shadow-[0_1px_--theme(--color-black/8%)] [&:is(:disabled,:active,[data-pressed])]:shadow-none",
-        outline:
-          "border-border bg-background shadow-xs not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:bg-input/32 dark:not-in-data-[slot=group]:bg-clip-border dark:not-disabled:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/4%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/8%)] [&:is(:disabled,:active,[data-pressed])]:shadow-none [&:is(:hover,[data-pressed])]:bg-accent/50 dark:[&:is(:hover,[data-pressed])]:bg-input/64",
-        secondary:
-          "border-secondary bg-secondary text-secondary-foreground hover:bg-secondary/90 data-pressed:bg-secondary/90",
-        destructive:
-          "border-destructive bg-destructive text-white shadow-xs shadow-destructive/24 not-disabled:inset-shadow-[0_1px_--theme(--color-white/16%)] hover:bg-destructive/90 [&:is(:active,[data-pressed])]:inset-shadow-[0_1px_--theme(--color-black/8%)] [&:is(:disabled,:active,[data-pressed])]:shadow-none",
-        "destructive-outline":
-          "border-border bg-transparent text-destructive-foreground shadow-xs not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:bg-input/32 dark:not-in-data-[slot=group]:bg-clip-border dark:not-disabled:before:shadow-[0_-1px_--theme(--color-white/4%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/8%)] [&:is(:disabled,:active,[data-pressed])]:shadow-none [&:is(:hover,[data-pressed])]:border-destructive/32 [&:is(:hover,[data-pressed])]:bg-destructive/4",
-        ghost: "border-transparent hover:bg-accent data-pressed:bg-accent",
-        link: "border-transparent underline-offset-4 hover:underline",
-      },
-      size: {
-        default:
-          "min-h-8 px-[calc(--spacing(3)-1px)] py-[calc(--spacing(1.5)-1px)]",
-        xs: "min-h-6 gap-1 rounded-md px-[calc(--spacing(2)-1px)] py-[calc(--spacing(1)-1px)] text-xs before:rounded-[calc(var(--radius-md)-1px)] [&_svg:not([class*='size-'])]:size-3",
-        sm: "min-h-7 gap-1.5 px-[calc(--spacing(2.5)-1px)] py-[calc(--spacing(1)-1px)]",
-        lg: "min-h-9 px-[calc(--spacing(3.5)-1px)] py-[calc(--spacing(2)-1px)]",
-        xl: "min-h-10 px-[calc(--spacing(4)-1px)] py-[calc(--spacing(2)-1px)] text-base [&_svg:not([class*='size-'])]:size-4.5",
-        icon: "size-8",
-        "icon-sm": "size-7",
-        "icon-lg": "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+import { buttonVariants } from "@/components/ui/button-variants"
 
 interface ButtonProps extends useRender.ComponentProps<"button"> {
   variant?: VariantProps<typeof buttonVariants>["variant"]
@@ -64,4 +28,4 @@ function Button({ className, variant, size, render, ...props }: ButtonProps) {
   })
 }
 
-export { Button, buttonVariants }
+export { Button }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Dialog as DialogPrimitive } from "@base-ui-components/react/dialog"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 import { XIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,6 +37,8 @@ function DialogBackdrop({
 
 function DialogPopup({
   backdropClassName,
+  containerClassName,
+  positionerClassName,
   className,
   children,
   showCloseButton = true,
@@ -44,12 +46,19 @@ function DialogPopup({
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
   backdropClassName?: string
+  containerClassName?: string
+  positionerClassName?: string
 }) {
   return (
     <DialogPortal>
       <DialogBackdrop className={backdropClassName} />
-      <div className="fixed inset-0 z-50">
-        <div className="flex h-[100dvh] flex-col items-center overflow-hidden pt-6 max-sm:before:flex-1 sm:overflow-y-auto sm:p-4 sm:before:basis-[20vh] sm:after:flex-1">
+      <div className={cn("fixed inset-0 z-50", containerClassName)}>
+        <div
+          className={cn(
+            "flex h-[100dvh] flex-col items-center overflow-hidden pt-6 max-sm:before:flex-1 sm:overflow-y-auto sm:p-4 sm:before:basis-[20vh] sm:after:flex-1",
+            positionerClassName
+          )}
+        >
           <DialogPrimitive.Popup
             data-slot="dialog-popup"
             className={cn(

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,16 +36,18 @@ function DialogBackdrop({
 }
 
 function DialogPopup({
+  backdropClassName,
   className,
   children,
   showCloseButton = true,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  backdropClassName?: string
 }) {
   return (
     <DialogPortal>
-      <DialogBackdrop />
+      <DialogBackdrop className={backdropClassName} />
       <div className="fixed inset-0 z-50">
         <div className="flex h-[100dvh] flex-col items-center overflow-hidden pt-6 max-sm:before:flex-1 sm:overflow-y-auto sm:p-4 sm:before:basis-[20vh] sm:after:flex-1">
           <DialogPrimitive.Popup

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -17,7 +17,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
 
 function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <kbd
+    <div
       data-slot="kbd-group"
       className={cn("inline-flex items-center gap-1", className)}
       {...props}

--- a/src/components/ui/preview-card.tsx
+++ b/src/components/ui/preview-card.tsx
@@ -1,4 +1,4 @@
-import { PreviewCard as PreviewCardPrimitive } from "@base-ui-components/react/preview-card"
+import { PreviewCard as PreviewCardPrimitive } from "@base-ui/react/preview-card"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,4 +1,4 @@
-import { Progress as ProgressPrimitive } from "@base-ui-components/react/progress"
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,4 +1,4 @@
-import { Separator as SeparatorPrimitive } from "@base-ui-components/react/separator"
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,4 +1,4 @@
-import { Toast } from "@base-ui-components/react/toast"
+import { Toast } from "@base-ui/react/toast"
 import {
   CircleAlertIcon,
   CircleCheckIcon,
@@ -8,7 +8,7 @@ import {
 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button-variants"
 
 const toastManager = Toast.createToastManager()
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,13 +1,57 @@
-import { Tooltip as TooltipPrimitive } from "@base-ui-components/react/tooltip"
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
 
 import { cn } from "@/lib/utils"
 
 const TooltipProvider = TooltipPrimitive.Provider
 
-const Tooltip = TooltipPrimitive.Root
+const TooltipTimingContext = React.createContext<{
+  delay?: number
+  closeDelay?: number
+}>({})
 
-function TooltipTrigger(props: TooltipPrimitive.Trigger.Props) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+type TooltipProps = TooltipPrimitive.Root.Props & {
+  delay?: number
+  closeDelay?: number
+  hoverable?: boolean
+}
+
+function Tooltip({
+  delay,
+  closeDelay,
+  hoverable,
+  disableHoverablePopup,
+  ...props
+}: TooltipProps) {
+  const resolvedDisableHoverablePopup =
+    disableHoverablePopup ??
+    (hoverable === false ? true : hoverable === true ? false : undefined)
+
+  return (
+    <TooltipTimingContext.Provider value={{ delay, closeDelay }}>
+      <TooltipPrimitive.Root
+        disableHoverablePopup={resolvedDisableHoverablePopup}
+        {...props}
+      />
+    </TooltipTimingContext.Provider>
+  )
+}
+
+function TooltipTrigger({
+  delay,
+  closeDelay,
+  ...props
+}: TooltipPrimitive.Trigger.Props) {
+  const timing = React.useContext(TooltipTimingContext)
+
+  return (
+    <TooltipPrimitive.Trigger
+      data-slot="tooltip-trigger"
+      delay={delay ?? timing.delay}
+      closeDelay={closeDelay ?? timing.closeDelay}
+      {...props}
+    />
+  )
 }
 
 function TooltipPopup({

--- a/src/routes/wall-of-papers.tsx
+++ b/src/routes/wall-of-papers.tsx
@@ -127,8 +127,10 @@ function RouteComponent() {
             <Dialog open={selected !== undefined} onOpenChange={handleDialogOpenChange}>
                 <DialogPopup
                     showCloseButton={false}
-                    backdropClassName="bg-black/75 backdrop-blur-sm"
-                    className="relative flex max-h-full max-w-7xl items-center justify-center border-none bg-transparent p-0 shadow-none sm:max-w-7xl sm:scale-100 sm:rounded-none before:hidden dark:before:hidden"
+                    backdropClassName="bg-black/75"
+                    containerClassName="pointer-events-none"
+                    positionerClassName="flex h-full w-full flex-row items-center justify-center overflow-hidden p-4 pointer-events-none pt-0 before:hidden after:hidden max-sm:before:hidden sm:overflow-hidden sm:p-4 sm:before:basis-0 sm:after:flex-none"
+                    className="pointer-events-auto relative flex h-full max-h-full w-full max-w-7xl items-center justify-center border-none bg-transparent p-0 shadow-none sm:max-w-7xl sm:scale-100 sm:rounded-none before:hidden dark:before:hidden"
                 >
                     {selected !== undefined && (
                         <>

--- a/src/routes/wall-of-papers.tsx
+++ b/src/routes/wall-of-papers.tsx
@@ -127,6 +127,7 @@ function RouteComponent() {
             <Dialog open={selected !== undefined} onOpenChange={handleDialogOpenChange}>
                 <DialogPopup
                     showCloseButton={false}
+                    backdropClassName="bg-black/75 backdrop-blur-sm"
                     className="relative flex max-h-full max-w-7xl items-center justify-center border-none bg-transparent p-0 shadow-none sm:max-w-7xl sm:scale-100 sm:rounded-none before:hidden dark:before:hidden"
                 >
                     {selected !== undefined && (

--- a/src/routes/wall-of-papers.tsx
+++ b/src/routes/wall-of-papers.tsx
@@ -18,10 +18,11 @@ import urbanSkyscrapersPortraitUrl from "@/assets/wallpapers/urban-skyscrapers-p
 import waterfallPortraitUrl from "@/assets/wallpapers/waterfall-portrait.jpeg?url";
 import winterLandscapePortraitUrl from "@/assets/wallpapers/winter-landscape-portrait.jpeg?url";
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogPopup } from '@/components/ui/dialog';
 import { useStorage } from '@/hooks/use-storage';
 import { createFileRoute } from '@tanstack/react-router';
-import { Heart } from 'lucide-react';
-import { useCallback, useEffect } from 'react';
+import { ChevronLeft, ChevronRight, Heart, X } from 'lucide-react';
+import { useCallback } from 'react';
 import { z } from 'zod/mini';
 
 export const Route = createFileRoute('/wall-of-papers')({
@@ -56,7 +57,7 @@ const wallpapers = [
 function RouteComponent() {
     const { i: selected } = Route.useSearch()
     const navigate = Route.useNavigate()
-    const [_, setSavedWallpaper] = useStorage<string | null>('favorite-wallpaper', { defaultValue: null })
+    const [, setSavedWallpaper] = useStorage<string | null>('favorite-wallpaper', { defaultValue: null })
 
     const openFullscreen = useCallback((index: number) => {
         navigate({ search: { i: index }, replace: true as const })
@@ -73,18 +74,23 @@ function RouteComponent() {
         }
     }, [selected, navigate, setSavedWallpaper])
 
-    const handleKeyDown = useCallback((e: KeyboardEvent) => {
-        if (e.key === 'Escape' && selected !== undefined) {
+    const handleDialogOpenChange = useCallback((open: boolean) => {
+        if (!open) {
             closeFullscreen()
         }
-    }, [selected, closeFullscreen])
+    }, [closeFullscreen])
 
-    useEffect(() => {
+    const goToPrevious = useCallback(() => {
         if (selected !== undefined) {
-            document.addEventListener('keydown', handleKeyDown)
-            return () => document.removeEventListener('keydown', handleKeyDown)
+            openFullscreen(selected > 0 ? selected - 1 : wallpapers.length - 1)
         }
-    }, [selected, handleKeyDown])
+    }, [selected, openFullscreen])
+
+    const goToNext = useCallback(() => {
+        if (selected !== undefined) {
+            openFullscreen(selected < wallpapers.length - 1 ? selected + 1 : 0)
+        }
+    }, [selected, openFullscreen])
 
     return (
         <>
@@ -118,76 +124,70 @@ function RouteComponent() {
                 </div>
             </div>
 
-            {/* Fullscreen Modal */}
-            {selected !== undefined && (
-                <div
-                    className='fixed inset-0 z-50 bg-black/75 backdrop-blur-sm flex items-center justify-center p-4'
-                    onClick={closeFullscreen}
+            <Dialog open={selected !== undefined} onOpenChange={handleDialogOpenChange}>
+                <DialogPopup
+                    showCloseButton={false}
+                    className="relative flex max-h-full max-w-7xl items-center justify-center border-none bg-transparent p-0 shadow-none sm:max-w-7xl sm:scale-100 sm:rounded-none before:hidden dark:before:hidden"
                 >
-                    <div
-                        className='relative max-w-7xl max-h-full w-full h-full flex items-center justify-center'
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        <img
-                            src={wallpapers[selected]}
-                            alt={`Wallpaper ${selected + 1}`}
-                            className='max-w-full max-h-full object-contain rounded-lg shadow-2xl'
-                            style={{ imageRendering: 'pixelated' }}
-                            decoding="async"
-                        />
+                    {selected !== undefined && (
+                        <>
+                            <img
+                                src={wallpapers[selected]}
+                                alt={`Wallpaper ${selected + 1}`}
+                                className='max-h-full max-w-full rounded-lg object-contain shadow-2xl'
+                                style={{ imageRendering: 'pixelated' }}
+                                decoding="async"
+                            />
 
-                        {/* Close button */}
-                        <button
-                            onClick={closeFullscreen}
-                            className='absolute top-4 right-4 bg-black/50 hover:bg-black/70 text-white rounded-full w-10 h-10 flex items-center justify-center transition-colors duration-200 backdrop-blur-sm'
-                            aria-label="Close fullscreen"
-                        >
-                            <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-                            </svg>
-                        </button>
+                            <Button
+                                onClick={closeFullscreen}
+                                variant="ghost"
+                                size="icon"
+                                className="absolute top-4 right-4 size-10 rounded-full bg-black/50 text-white backdrop-blur-sm hover:bg-black/70"
+                                aria-label="Close fullscreen"
+                            >
+                                <X className="size-6" />
+                            </Button>
 
-                        {/* Bottom controls */}
-                        <div className='absolute bottom-4 left-0 right-0 flex items-center justify-between px-4 gap-4'>
-                            {/* Image counter */}
-                            <div className='bg-black/50 backdrop-blur-sm px-4 py-2 rounded-full text-white text-sm'>
-                                {selected + 1} / {wallpapers.length}
+                            <div className='absolute bottom-4 left-0 right-0 flex items-center justify-between gap-4 px-4'>
+                                <div className='rounded-full bg-black/50 px-4 py-2 text-sm text-white backdrop-blur-sm'>
+                                    {selected + 1} / {wallpapers.length}
+                                </div>
+
+                                <Button
+                                    onClick={handleLikeWallpaper}
+                                    variant="ghost"
+                                    size="icon"
+                                    className="size-10 rounded-full bg-black/50 text-white backdrop-blur-sm hover:bg-black/70"
+                                >
+                                    <Heart className="size-4" />
+                                    <span className="sr-only">Like</span>
+                                </Button>
                             </div>
 
-                            {/* I like this button */}
                             <Button
-                                onClick={handleLikeWallpaper}
+                                onClick={goToPrevious}
                                 variant="ghost"
-                                className="size-10"
+                                size="icon"
+                                className="absolute left-4 top-1/2 size-12 -translate-y-1/2 rounded-full bg-black/50 text-white backdrop-blur-sm hover:bg-black/70"
+                                aria-label="Previous image"
                             >
-                                <Heart className="size-4" />
-                                <span className="sr-only">Like</span>
+                                <ChevronLeft className="size-6" />
                             </Button>
-                        </div>
 
-                        {/* Navigation arrows */}
-                        <button
-                            onClick={() => openFullscreen(selected > 0 ? selected - 1 : wallpapers.length - 1)}
-                            className='absolute left-4 top-1/2 transform -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full w-12 h-12 flex items-center justify-center transition-colors duration-200 backdrop-blur-sm'
-                            aria-label="Previous image"
-                        >
-                            <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M15 19l-7-7 7-7' />
-                            </svg>
-                        </button>
-
-                        <button
-                            onClick={() => openFullscreen(selected < wallpapers.length - 1 ? selected + 1 : 0)}
-                            className='absolute right-4 top-1/2 transform -translate-y-1/2 bg-black/50 hover:bg-black/70 text-white rounded-full w-12 h-12 flex items-center justify-center transition-colors duration-200 backdrop-blur-sm'
-                            aria-label="Next image"
-                        >
-                            <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M9 5l7 7-7 7' />
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-            )}
+                            <Button
+                                onClick={goToNext}
+                                variant="ghost"
+                                size="icon"
+                                className="absolute right-4 top-1/2 size-12 -translate-y-1/2 rounded-full bg-black/50 text-white backdrop-blur-sm hover:bg-black/70"
+                                aria-label="Next image"
+                            >
+                                <ChevronRight className="size-6" />
+                            </Button>
+                        </>
+                    )}
+                </DialogPopup>
+            </Dialog>
         </>
     )
 }


### PR DESCRIPTION
## Summary
- Replace deprecated Base UI package imports with @base-ui/react.
- Split primitive variant exports and migrate wallpaper fullscreen UI onto Dialog/Button primitives.

## Test plan
- bun install --frozen-lockfile
- bun run typecheck
- bun run build
- bun run lint
- bun outdated

Made with [Cursor](https://cursor.com)