### PR TITLE
Defer game runtime loading

### DIFF
--- a/src/components/cheats/game.tsx
+++ b/src/components/cheats/game.tsx
@@ -4,7 +4,7 @@ import { Dialog, DialogDescription, DialogFooter, DialogHeader, DialogPopup, Dia
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { Tooltip, TooltipPopup, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useGame } from "@/contexts/game";
-import { Man } from "@/lib/mario-game";
+import { Man } from "@/lib/game-assets";
 import { useNavigate } from '@tanstack/react-router';
 import { Gamepad2, Loader2, Music, Play, Square, Volume2, VolumeX } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -75,9 +75,11 @@ export function Game() {
     useEffect(() => {
         if (!characterRef.current) return;
 
-        const game = addPlayer(characterRef.current);
-        return () => game?.dispose();
-    }, [addPlayer]);
+        void addPlayer(characterRef.current);
+        return () => {
+            stopGame();
+        };
+    }, [addPlayer, stopGame]);
 
     return (
         <>

--- a/src/components/github-contributions.tsx
+++ b/src/components/github-contributions.tsx
@@ -1,8 +1,7 @@
 import { useTheme } from "@/contexts/theme";
 import GitHubCalendar from "react-github-calendar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
-import { GameSurface } from "@/lib/mario-game";
-import { GameElement } from "@/lib/mario-game";
+import { GameElement, GameSurface } from "@/lib/game-types";
 import { useGameElement } from "@/hooks/use-game-element";
 
 type Activity = {

--- a/src/contexts/game.tsx
+++ b/src/contexts/game.tsx
@@ -8,7 +8,6 @@ const NOOP_SOUND: GameSoundHandler = () => { };
 type CreateGameSoundHandler = typeof import("@/lib/mario-game").createGameSoundHandler;
 
 export interface GameContextType {
-    game: MarioGame | null;
     isRunning: boolean;
     soundEnabled: boolean;
     musicEnabled: boolean;
@@ -270,10 +269,9 @@ export function GameProvider({ children, options }: { children: React.ReactNode;
     }, []);
 
     const updateOptions = applyOptions;
-    const game = gameRef.current;
 
     return (
-        <GameContext.Provider value={{ game, isRunning, soundEnabled, musicEnabled, addPlayer, addElement, updateOptions, options: currentOptions, startGame, stopGame, toggleSound, toggleMusic }}>
+        <GameContext.Provider value={{ isRunning, soundEnabled, musicEnabled, addPlayer, addElement, updateOptions, options: currentOptions, startGame, stopGame, toggleSound, toggleMusic }}>
             {children}
         </GameContext.Provider>
     );

--- a/src/contexts/game.tsx
+++ b/src/contexts/game.tsx
@@ -11,7 +11,7 @@ export interface GameContextType {
     isRunning: boolean;
     soundEnabled: boolean;
     musicEnabled: boolean;
-    addPlayer: (playerEl: HTMLImageElement) => Promise<MarioGame>;
+    addPlayer: (playerEl: HTMLImageElement) => Promise<MarioGame | null>;
     addElement: (dom: HTMLElement | SVGElement, config: GameElementRegistration) => (() => void) | null;
     updateOptions: (options: GameOptions) => void;
     options: GameOptions;
@@ -30,12 +30,28 @@ export function GameProvider({ children, options }: { children: React.ReactNode;
     const [musicEnabled, setMusicEnabled] = useState(true);
     const backgroundMusicRef = useRef<HTMLAudioElement | null>(null);
     const pendingStartRef = useRef(false);
+    const loadGenerationRef = useRef(0);
     const registeredElements = useRef(
         new Map<HTMLElement | SVGElement, { options: GameElementRegistration; detach: (() => void) | null }>(),
     );
     const defaultSoundHandlerRef = useRef<GameSoundHandler | null>(null);
     const optionsRef = useRef<GameOptions>(options ?? {});
     const [currentOptions, setCurrentOptions] = useState<GameOptions>(() => options ?? {});
+    const soundEnabledRef = useRef(soundEnabled);
+    const musicEnabledRef = useRef(musicEnabled);
+
+    useEffect(() => {
+        soundEnabledRef.current = soundEnabled;
+    }, [soundEnabled]);
+
+    useEffect(() => {
+        musicEnabledRef.current = musicEnabled;
+    }, [musicEnabled]);
+
+    const invalidatePendingLoads = useCallback(() => {
+        loadGenerationRef.current += 1;
+        pendingStartRef.current = false;
+    }, []);
 
     const ensureBackgroundMusic = useCallback(async () => {
         if (!backgroundMusicRef.current) {
@@ -81,44 +97,57 @@ export function GameProvider({ children, options }: { children: React.ReactNode;
         gameRef.current.start();
         setIsRunning(true);
 
-        if (musicEnabled) {
+        if (musicEnabledRef.current) {
             await playBackgroundMusic();
         }
-    }, [musicEnabled, playBackgroundMusic]);
+    }, [playBackgroundMusic]);
 
     const addPlayer = useCallback(async (playerEl: HTMLImageElement) => {
+        const generation = loadGenerationRef.current + 1;
+        loadGenerationRef.current = generation;
+
         gameRef.current?.dispose();
         gameRef.current = null;
         setIsRunning(false);
 
         const [{ MarioGame, createGameSoundHandler }, soundscapeModule] = await Promise.all([
             import("@/lib/mario-game"),
-            soundEnabled ? import("@/lib/mario-soundscape") : Promise.resolve(null),
+            soundEnabledRef.current ? import("@/lib/mario-soundscape") : Promise.resolve(null),
         ]);
 
-        if (soundEnabled && soundscapeModule && !defaultSoundHandlerRef.current) {
+        if (generation !== loadGenerationRef.current) {
+            return null;
+        }
+
+        if (soundEnabledRef.current && soundscapeModule && !defaultSoundHandlerRef.current) {
             defaultSoundHandlerRef.current = soundscapeModule.createDefaultMarioSoundHandler();
         }
 
         const normalized = normalizeGameOptions(
             optionsRef.current,
-            soundEnabled ? defaultSoundHandlerRef.current ?? undefined : undefined,
+            soundEnabledRef.current ? defaultSoundHandlerRef.current ?? undefined : undefined,
             createGameSoundHandler,
         );
         optionsRef.current = normalized;
         setCurrentOptions(normalized);
 
         const newGame = new MarioGame(playerEl, optionsRef.current);
+
+        if (generation !== loadGenerationRef.current) {
+            newGame.dispose();
+            return null;
+        }
+
         gameRef.current = newGame;
         attachRegisteredElements();
 
-        if (pendingStartRef.current) {
+        if (pendingStartRef.current && generation === loadGenerationRef.current) {
             pendingStartRef.current = false;
             await startGameInternal();
         }
 
         return newGame;
-    }, [attachRegisteredElements, soundEnabled, startGameInternal]);
+    }, [attachRegisteredElements, startGameInternal]);
 
     const addElement = useCallback((dom: HTMLElement | SVGElement, config: GameElementRegistration) => {
         const normalizedConfig: GameElementRegistration = {
@@ -199,7 +228,7 @@ export function GameProvider({ children, options }: { children: React.ReactNode;
     }, [startGameInternal]);
 
     const stopGame = useCallback(() => {
-        pendingStartRef.current = false;
+        invalidatePendingLoads();
 
         if (gameRef.current) {
             gameRef.current.dispose();
@@ -207,7 +236,7 @@ export function GameProvider({ children, options }: { children: React.ReactNode;
         }
         setIsRunning(false);
         pauseBackgroundMusic();
-    }, [pauseBackgroundMusic]);
+    }, [invalidatePendingLoads, pauseBackgroundMusic]);
 
     const toggleSound = useCallback(() => {
         setSoundEnabled(prev => {
@@ -254,7 +283,7 @@ export function GameProvider({ children, options }: { children: React.ReactNode;
 
     useEffect(() => {
         return () => {
-            pendingStartRef.current = false;
+            invalidatePendingLoads();
 
             if (gameRef.current) {
                 gameRef.current.dispose();
@@ -266,7 +295,7 @@ export function GameProvider({ children, options }: { children: React.ReactNode;
                 backgroundMusicRef.current = null;
             }
         };
-    }, []);
+    }, [invalidatePendingLoads]);
 
     const updateOptions = applyOptions;
 

--- a/src/contexts/game.tsx
+++ b/src/contexts/game.tsx
@@ -1,17 +1,18 @@
-import backgroundMusicSrc from "@/assets/audio/8-bit-background.mp3";
-import { MarioGame, createGameSoundHandler, type GameElementRegistration, type GameOptions, type GameSoundHandler } from "@/lib/mario-game";
-import { createDefaultMarioSoundHandler } from "@/lib/mario-soundscape";
+import type { GameElementRegistration, GameOptions, GameSoundHandler } from "@/lib/game-types";
+import type { MarioGame } from "@/lib/mario-game";
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 
 // No-op sound handler for when sound is disabled
 const NOOP_SOUND: GameSoundHandler = () => { };
+
+type CreateGameSoundHandler = typeof import("@/lib/mario-game").createGameSoundHandler;
 
 export interface GameContextType {
     game: MarioGame | null;
     isRunning: boolean;
     soundEnabled: boolean;
     musicEnabled: boolean;
-    addPlayer: (playerEl: HTMLImageElement) => MarioGame;
+    addPlayer: (playerEl: HTMLImageElement) => Promise<MarioGame>;
     addElement: (dom: HTMLElement | SVGElement, config: GameElementRegistration) => (() => void) | null;
     updateOptions: (options: GameOptions) => void;
     options: GameOptions;
@@ -29,20 +30,37 @@ export function GameProvider({ children, options }: { children: React.ReactNode;
     const [soundEnabled, setSoundEnabled] = useState(true);
     const [musicEnabled, setMusicEnabled] = useState(true);
     const backgroundMusicRef = useRef<HTMLAudioElement | null>(null);
+    const pendingStartRef = useRef(false);
     const registeredElements = useRef(
         new Map<HTMLElement | SVGElement, { options: GameElementRegistration; detach: (() => void) | null }>(),
     );
-    const defaultSoundHandlerRef = useRef(createDefaultMarioSoundHandler());
-    const optionsRef = useRef<GameOptions>(normalizeGameOptions(options ?? {}, defaultSoundHandlerRef.current));
-    const [currentOptions, setCurrentOptions] = useState<GameOptions>(optionsRef.current);
+    const defaultSoundHandlerRef = useRef<GameSoundHandler | null>(null);
+    const optionsRef = useRef<GameOptions>(options ?? {});
+    const [currentOptions, setCurrentOptions] = useState<GameOptions>(() => options ?? {});
 
-    const applyOptions = useCallback((next: GameOptions) => {
-        if (!next) return;
-        const normalized = normalizeGameOptions(next, soundEnabled ? defaultSoundHandlerRef.current : undefined);
-        optionsRef.current = { ...optionsRef.current, ...normalized };
-        setCurrentOptions(optionsRef.current);
-        gameRef.current?.updateOptions(optionsRef.current);
-    }, [soundEnabled]);
+    const ensureBackgroundMusic = useCallback(async () => {
+        if (!backgroundMusicRef.current) {
+            const { default: backgroundMusicSrc } = await import("@/assets/audio/8-bit-background.mp3");
+            backgroundMusicRef.current = new Audio(backgroundMusicSrc);
+            backgroundMusicRef.current.loop = true;
+            backgroundMusicRef.current.volume = 0.3;
+        }
+
+        return backgroundMusicRef.current;
+    }, []);
+
+    const playBackgroundMusic = useCallback(async () => {
+        const audio = await ensureBackgroundMusic();
+        audio.play().catch(() => {
+            // Ignore play errors (user interaction required)
+        });
+    }, [ensureBackgroundMusic]);
+
+    const pauseBackgroundMusic = useCallback(() => {
+        if (!backgroundMusicRef.current) return;
+        backgroundMusicRef.current.pause();
+        backgroundMusicRef.current.currentTime = 0;
+    }, []);
 
     const attachRegisteredElements = useCallback(() => {
         const game = gameRef.current;
@@ -58,16 +76,50 @@ export function GameProvider({ children, options }: { children: React.ReactNode;
         }
     }, []);
 
-    const addPlayer = useCallback((playerEl: HTMLImageElement) => {
+    const startGameInternal = useCallback(async () => {
+        if (!gameRef.current) return;
+
+        gameRef.current.start();
+        setIsRunning(true);
+
+        if (musicEnabled) {
+            await playBackgroundMusic();
+        }
+    }, [musicEnabled, playBackgroundMusic]);
+
+    const addPlayer = useCallback(async (playerEl: HTMLImageElement) => {
         gameRef.current?.dispose();
+        gameRef.current = null;
         setIsRunning(false);
+
+        const [{ MarioGame, createGameSoundHandler }, soundscapeModule] = await Promise.all([
+            import("@/lib/mario-game"),
+            soundEnabled ? import("@/lib/mario-soundscape") : Promise.resolve(null),
+        ]);
+
+        if (soundEnabled && soundscapeModule && !defaultSoundHandlerRef.current) {
+            defaultSoundHandlerRef.current = soundscapeModule.createDefaultMarioSoundHandler();
+        }
+
+        const normalized = normalizeGameOptions(
+            optionsRef.current,
+            soundEnabled ? defaultSoundHandlerRef.current ?? undefined : undefined,
+            createGameSoundHandler,
+        );
+        optionsRef.current = normalized;
+        setCurrentOptions(normalized);
 
         const newGame = new MarioGame(playerEl, optionsRef.current);
         gameRef.current = newGame;
         attachRegisteredElements();
 
+        if (pendingStartRef.current) {
+            pendingStartRef.current = false;
+            await startGameInternal();
+        }
+
         return newGame;
-    }, [attachRegisteredElements]);
+    }, [attachRegisteredElements, soundEnabled, startGameInternal]);
 
     const addElement = useCallback((dom: HTMLElement | SVGElement, config: GameElementRegistration) => {
         const normalizedConfig: GameElementRegistration = {
@@ -112,51 +164,77 @@ export function GameProvider({ children, options }: { children: React.ReactNode;
         return cleanup;
     }, []);
 
+    const applyOptions = useCallback(async (next: GameOptions) => {
+        if (!next) return;
+
+        const needsEngine = Boolean(next.soundMap && !next.onSound);
+        let createGameSoundHandler: CreateGameSoundHandler | undefined;
+
+        if (needsEngine) {
+            ({ createGameSoundHandler } = await import("@/lib/mario-game"));
+        }
+
+        const normalized = normalizeGameOptions(
+            next,
+            soundEnabled ? defaultSoundHandlerRef.current ?? undefined : undefined,
+            createGameSoundHandler,
+        );
+        optionsRef.current = { ...optionsRef.current, ...normalized };
+        setCurrentOptions(optionsRef.current);
+        gameRef.current?.updateOptions(optionsRef.current);
+    }, [soundEnabled]);
+
     useEffect(() => {
         if (options) {
-            applyOptions(options);
+            void applyOptions(options);
         }
     }, [options, applyOptions]);
 
     const startGame = useCallback(() => {
-        if (!gameRef.current) return;
-        gameRef.current.start();
-        setIsRunning(true);
-
-        // Start background music if enabled
-        if (musicEnabled && backgroundMusicRef.current) {
-            backgroundMusicRef.current.play().catch(() => {
-                // Ignore play errors (user interaction required)
-            });
+        if (!gameRef.current) {
+            pendingStartRef.current = true;
+            return;
         }
-    }, [musicEnabled]);
+
+        void startGameInternal();
+    }, [startGameInternal]);
 
     const stopGame = useCallback(() => {
+        pendingStartRef.current = false;
+
         if (gameRef.current) {
             gameRef.current.dispose();
             gameRef.current = null;
         }
         setIsRunning(false);
-
-        // Stop background music
-        if (backgroundMusicRef.current) {
-            backgroundMusicRef.current.pause();
-            backgroundMusicRef.current.currentTime = 0;
-        }
-    }, []);
+        pauseBackgroundMusic();
+    }, [pauseBackgroundMusic]);
 
     const toggleSound = useCallback(() => {
         setSoundEnabled(prev => {
             const newValue = !prev;
-            // Update game options if game is running
+
             if (gameRef.current) {
-                const newOptions = {
-                    ...optionsRef.current,
-                    onSound: newValue ? defaultSoundHandlerRef.current : NOOP_SOUND
-                };
-                optionsRef.current = newOptions;
-                gameRef.current.updateOptions(newOptions);
+                void (async () => {
+                    let handler: GameSoundHandler = NOOP_SOUND;
+
+                    if (newValue) {
+                        if (!defaultSoundHandlerRef.current) {
+                            const { createDefaultMarioSoundHandler } = await import("@/lib/mario-soundscape");
+                            defaultSoundHandlerRef.current = createDefaultMarioSoundHandler();
+                        }
+                        handler = defaultSoundHandlerRef.current;
+                    }
+
+                    const newOptions = {
+                        ...optionsRef.current,
+                        onSound: newValue ? handler : NOOP_SOUND,
+                    };
+                    optionsRef.current = newOptions;
+                    gameRef.current?.updateOptions(newOptions);
+                })();
             }
+
             return newValue;
         });
     }, []);
@@ -164,29 +242,26 @@ export function GameProvider({ children, options }: { children: React.ReactNode;
     const toggleMusic = useCallback(() => {
         setMusicEnabled(prev => {
             const newValue = !prev;
-            // Control background music
-            if (backgroundMusicRef.current) {
-                if (newValue && isRunning) {
-                    backgroundMusicRef.current.play().catch(() => {
-                        // Ignore play errors (user interaction required)
-                    });
-                } else {
-                    backgroundMusicRef.current.pause();
-                }
+
+            if (newValue && isRunning) {
+                void playBackgroundMusic();
+            } else if (!newValue && backgroundMusicRef.current) {
+                backgroundMusicRef.current.pause();
             }
+
             return newValue;
         });
-    }, [isRunning]);
+    }, [isRunning, playBackgroundMusic]);
 
-    // Initialize background music
     useEffect(() => {
-        if (!backgroundMusicRef.current) {
-            backgroundMusicRef.current = new Audio(backgroundMusicSrc);
-            backgroundMusicRef.current.loop = true;
-            backgroundMusicRef.current.volume = 0.3; // Low volume for background
-        }
-
         return () => {
+            pendingStartRef.current = false;
+
+            if (gameRef.current) {
+                gameRef.current.dispose();
+                gameRef.current = null;
+            }
+
             if (backgroundMusicRef.current) {
                 backgroundMusicRef.current.pause();
                 backgroundMusicRef.current = null;
@@ -212,10 +287,14 @@ export function useGame() {
     return context;
 }
 
-function normalizeGameOptions(options: GameOptions, defaultHandler?: GameSoundHandler): GameOptions {
+function normalizeGameOptions(
+    options: GameOptions,
+    defaultHandler?: GameSoundHandler,
+    createGameSoundHandler?: CreateGameSoundHandler,
+): GameOptions {
     const normalized: GameOptions = { ...options };
 
-    if (normalized.soundMap && !normalized.onSound) {
+    if (normalized.soundMap && !normalized.onSound && createGameSoundHandler) {
         normalized.onSound = createGameSoundHandler(normalized.soundMap);
     }
 

--- a/src/hooks/use-game-element.ts
+++ b/src/hooks/use-game-element.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react"
 import type { DependencyList } from "react"
 
 import { useGame } from "@/contexts/game"
-import type { GameElementRegistration } from "@/lib/mario-game"
+import type { GameElementRegistration } from "@/lib/game-types"
 
 function normalizeConfig(config: Omit<GameElementRegistration, 'events'>): Omit<GameElementRegistration, 'events'> {
     return {

--- a/src/lib/game-assets.ts
+++ b/src/lib/game-assets.ts
@@ -1,0 +1,17 @@
+import manCartwheelingMediumDarkSrc from "@/assets/animated/man_cartwheeling_medium-dark.png"
+import manDancingMediumDarkSrc from "@/assets/animated/man_dancing_medium-dark.png"
+import manRunningFacingRightMediumDarkSrc from "@/assets/animated/man_running_facing_right_medium-dark.png"
+import manRunningMediumDarkSrc from "@/assets/animated/man_running_medium-dark.png"
+import manStandingMediumDarkSrc from "@/assets/animated/man_standing_medium-dark.png"
+import manWalkingFacingRightMediumDarkSrc from "@/assets/animated/man_walking_facing_right_medium-dark.png"
+import manWalkingMediumDarkSrc from "@/assets/animated/man_walking_medium-dark.png"
+
+export const Man = {
+    CARTWHEELING: manCartwheelingMediumDarkSrc,
+    DANCING: manDancingMediumDarkSrc,
+    RUNNING_RIGHT: manRunningFacingRightMediumDarkSrc,
+    RUNNING_LEFT: manRunningMediumDarkSrc,
+    STANDING: manStandingMediumDarkSrc,
+    WALKING_RIGHT: manWalkingFacingRightMediumDarkSrc,
+    WALKING_LEFT: manWalkingMediumDarkSrc,
+} as const;

--- a/src/lib/game-types.ts
+++ b/src/lib/game-types.ts
@@ -1,0 +1,124 @@
+export enum GameElement {
+    PLATFORM = "platform",
+}
+
+export const COLLISION = {
+    NONE: 0,
+    TOP: 1 << 0,
+    BOTTOM: 1 << 1,
+    LEFT: 1 << 2,
+    RIGHT: 1 << 3,
+    VERTICAL: (1 << 0) | (1 << 1),
+    HORIZONTAL: (1 << 2) | (1 << 3),
+    ALL: (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3),
+} as const;
+
+export type CollisionMask =
+    (typeof COLLISION)[keyof typeof COLLISION];
+
+export type CollisionSides = Partial<{
+    top: boolean;
+    bottom: boolean;
+    left: boolean;
+    right: boolean;
+}>;
+
+export interface PassThroughConfig {
+    upward?: boolean;
+    downward?: boolean;
+    leftward?: boolean;
+    rightward?: boolean;
+}
+
+export interface GameRect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export enum GameSoundEvent {
+    LAND = "land",
+    JUMP = "jump",
+    FALL = "fall",
+    FOOTSTEP = "footstep",
+    COLLIDE = "collide",
+}
+
+export enum GameSurface {
+    DEFAULT = "default",
+    WOOD = "wood",
+    METAL = "metal",
+    GLASS = "glass",
+    CARPET = "carpet",
+    CONCRETE = "concrete",
+    GRASS = "grass",
+    SNOW = "snow",
+    BELL = "bell",
+    PLATE = "plate",
+}
+
+export interface GameSoundSupport {
+    element: HTMLElement | SVGElement;
+    type: GameElement;
+    rect: GameRect;
+    surface: GameSurface;
+}
+
+export interface GameSoundPayload {
+    type: GameSoundEvent;
+    dt: number;
+    position: { x: number; y: number };
+    velocity: { x: number; y: number };
+    intensity?: number;
+    support: GameSoundSupport | null;
+    meta?: Record<string, unknown>;
+}
+
+export type GameSoundHandler = (event: GameSoundEvent, payload: GameSoundPayload) => void;
+
+export interface GameSoundSpec {
+    src: string;
+    volume?: number;
+    playbackRate?: number;
+}
+
+export type GameSoundDefinition =
+    | string
+    | HTMLAudioElement
+    | GameSoundSpec
+    | ((event: GameSoundEvent, payload: GameSoundPayload) => void);
+
+export type GameSoundMap = Partial<Record<GameSoundEvent, GameSoundDefinition>>;
+
+export interface GameOptions {
+    footstepInterval?: number;
+    onSound?: GameSoundHandler;
+    soundMap?: GameSoundMap;
+}
+
+export type GameElementEventPayload = {
+    element: HTMLElement | SVGElement;
+    direction?: "left" | "right" | "top" | "bottom";
+    speed?: number;
+    metadata?: Record<string, unknown>;
+};
+
+export type GameElementEventHandler = (payload: GameElementEventPayload) => void;
+
+export type GameElementEvents = {
+    onPlayerEnter?: GameElementEventHandler;
+    onPlayerLeave?: GameElementEventHandler;
+    onPlayerCollide?: GameElementEventHandler;
+};
+
+export type GameElementRegistration = {
+    type: GameElement;
+    collisionSides?: CollisionSides;
+    collisionMask?: CollisionMask;
+    passThrough?: PassThroughConfig;
+    solid?: boolean;
+    metadata?: Record<string, unknown>;
+    surface?: GameSurface;
+    events?: GameElementEvents;
+};

--- a/src/lib/mario-game.ts
+++ b/src/lib/mario-game.ts
@@ -1,53 +1,47 @@
-import manCartwheelingMediumDarkSrc from "@/assets/animated/man_cartwheeling_medium-dark.png"
-import manDancingMediumDarkSrc from "@/assets/animated/man_dancing_medium-dark.png"
-import manRunningFacingRightMediumDarkSrc from "@/assets/animated/man_running_facing_right_medium-dark.png"
-import manRunningMediumDarkSrc from "@/assets/animated/man_running_medium-dark.png"
-import manStandingMediumDarkSrc from "@/assets/animated/man_standing_medium-dark.png"
-import manWalkingFacingRightMediumDarkSrc from "@/assets/animated/man_walking_facing_right_medium-dark.png"
-import manWalkingMediumDarkSrc from "@/assets/animated/man_walking_medium-dark.png"
+import { Man } from "@/lib/game-assets"
+import {
+    COLLISION,
+    GameElement,
+    GameSoundEvent,
+    GameSurface,
+    type CollisionMask,
+    type CollisionSides,
+    type GameElementEventPayload,
+    type GameElementEvents,
+    type GameElementRegistration,
+    type GameOptions,
+    type GameRect,
+    type GameSoundDefinition,
+    type GameSoundHandler,
+    type GameSoundMap,
+    type GameSoundPayload,
+    type GameSoundSpec,
+    type GameSoundSupport,
+    type PassThroughConfig,
+} from "@/lib/game-types"
 import { cancelFrame, frame, type FrameData } from "motion"
 
-export const Man = {
-    CARTWHEELING: manCartwheelingMediumDarkSrc,
-    DANCING: manDancingMediumDarkSrc,
-    RUNNING_RIGHT: manRunningFacingRightMediumDarkSrc,
-    RUNNING_LEFT: manRunningMediumDarkSrc,
-    STANDING: manStandingMediumDarkSrc,
-    WALKING_RIGHT: manWalkingFacingRightMediumDarkSrc,
-    WALKING_LEFT: manWalkingMediumDarkSrc,
-} as const;
-
-export enum GameElement {
-    PLATFORM = "platform",
-}
-
-export const COLLISION = {
-    NONE: 0,
-    TOP: 1 << 0,
-    BOTTOM: 1 << 1,
-    LEFT: 1 << 2,
-    RIGHT: 1 << 3,
-    VERTICAL: (1 << 0) | (1 << 1),
-    HORIZONTAL: (1 << 2) | (1 << 3),
-    ALL: (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3),
-} as const;
-
-export type CollisionMask =
-    (typeof COLLISION)[keyof typeof COLLISION];
-
-export type CollisionSides = Partial<{
-    top: boolean;
-    bottom: boolean;
-    left: boolean;
-    right: boolean;
-}>;
-
-export interface PassThroughConfig {
-    upward?: boolean;
-    downward?: boolean;
-    leftward?: boolean;
-    rightward?: boolean;
-}
+export {
+    COLLISION,
+    GameElement,
+    GameSoundEvent,
+    GameSurface,
+    type CollisionMask,
+    type CollisionSides,
+    type GameElementEventPayload,
+    type GameElementEventHandler,
+    type GameElementEvents,
+    type GameElementRegistration,
+    type GameOptions,
+    type GameRect,
+    type GameSoundDefinition,
+    type GameSoundHandler,
+    type GameSoundMap,
+    type GameSoundPayload,
+    type GameSoundSpec,
+    type GameSoundSupport,
+    type PassThroughConfig,
+} from "@/lib/game-types"
 
 interface GameElementBehavior {
     solid: boolean;
@@ -102,99 +96,6 @@ type PlayerState =
     | "JUMPING_LEFT"
     | "JUMPING_RIGHT"
     | "JUMPING";
-
-export interface GameRect {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-}
-
-export enum GameSoundEvent {
-    LAND = "land",
-    JUMP = "jump",
-    FALL = "fall",
-    FOOTSTEP = "footstep",
-    COLLIDE = "collide",
-}
-
-export enum GameSurface {
-    DEFAULT = "default",
-    WOOD = "wood",
-    METAL = "metal",
-    GLASS = "glass",
-    CARPET = "carpet",
-    CONCRETE = "concrete",
-    GRASS = "grass",
-    SNOW = "snow",
-    BELL = "bell",
-    PLATE = "plate",
-}
-
-export interface GameSoundSupport {
-    element: HTMLElement | SVGElement;
-    type: GameElement;
-    rect: GameRect;
-    surface: GameSurface;
-}
-
-export interface GameSoundPayload {
-    type: GameSoundEvent;
-    dt: number;
-    position: { x: number; y: number };
-    velocity: { x: number; y: number };
-    intensity?: number;
-    support: GameSoundSupport | null;
-    meta?: Record<string, unknown>;
-}
-
-export type GameSoundHandler = (event: GameSoundEvent, payload: GameSoundPayload) => void;
-
-export interface GameSoundSpec {
-    src: string;
-    volume?: number;
-    playbackRate?: number;
-}
-
-export type GameSoundDefinition =
-    | string
-    | HTMLAudioElement
-    | GameSoundSpec
-    | ((event: GameSoundEvent, payload: GameSoundPayload) => void);
-
-export type GameSoundMap = Partial<Record<GameSoundEvent, GameSoundDefinition>>;
-
-export interface GameOptions {
-    footstepInterval?: number;
-    onSound?: GameSoundHandler;
-    soundMap?: GameSoundMap;
-}
-
-export type GameElementEventPayload = {
-    element: HTMLElement | SVGElement;
-    direction?: "left" | "right" | "top" | "bottom";
-    speed?: number;
-    metadata?: Record<string, unknown>;
-};
-
-export type GameElementEventHandler = (payload: GameElementEventPayload) => void;
-
-export type GameElementEvents = {
-    onPlayerEnter?: GameElementEventHandler;
-    onPlayerLeave?: GameElementEventHandler;
-    onPlayerCollide?: GameElementEventHandler;
-};
-
-export type GameElementRegistration = {
-    type: GameElement;
-    collisionSides?: CollisionSides;
-    collisionMask?: CollisionMask;
-    passThrough?: PassThroughConfig;
-    solid?: boolean;
-    metadata?: Record<string, unknown>;
-    surface?: GameSurface;
-    events?: GameElementEvents;
-};
 
 const DEFAULT_FOOTSTEP_INTERVAL = 0.32;
 const NOOP_SOUND: GameSoundHandler = () => { };
@@ -326,6 +227,7 @@ const MOVEMENT_KEYS = new Set([
 ]);
 
 export class MarioGame {
+    private isLoopRunning = false;
     private vx = 0; // horizontal velocity (px/sec)
     private vy = 0; // vertical velocity (px/sec)
     private x = 80; // horizontal position (px)
@@ -393,8 +295,14 @@ export class MarioGame {
     }
 
     start() {
+        if (this.isLoopRunning) return;
+
+        this.isLoopRunning = true;
         const process = frame.preRender(this.tick, true);
-        this.disposables.add(() => cancelFrame(process));
+        this.disposables.add(() => {
+            cancelFrame(process);
+            this.isLoopRunning = false;
+        });
     }
 
     addElement(dom: HTMLElement | SVGElement, options: GameElementRegistration) {

--- a/src/lib/mario-soundscape.ts
+++ b/src/lib/mario-soundscape.ts
@@ -1,10 +1,10 @@
 import {
-    createGameSoundHandler,
     GameSoundEvent,
     GameSurface,
     type GameSoundHandler,
     type GameSoundMap,
-} from "@/lib/mario-game";
+} from "@/lib/game-types";
+import { createGameSoundHandler } from "@/lib/mario-game";
 
 import footstepCarpet000Url from "../assets/audio/footstep_carpet_000.ogg?url";
 import footstepCarpet001Url from "../assets/audio/footstep_carpet_001.ogg?url";

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,7 +12,7 @@ import { projects, type Project, type Project as ProjectItem } from "@/data/proj
 import { stack, type Stack } from "@/data/stack"
 import { works, type Work } from "@/data/works"
 import { useGameElement } from '@/hooks/use-game-element'
-import { GameElement, GameSurface } from '@/lib/mario-game'
+import { GameElement, GameSurface } from '@/lib/game-types'
 import { formatDate } from '@/lib/date'
 import { cn } from '@/lib/utils'
 import { createFileRoute, Link } from '@tanstack/react-router'


### PR DESCRIPTION
## Summary
- Split lightweight game types/assets from the heavy engine.
- Dynamically load engine, soundscape, and background music with guarded lifecycle cleanup.

## Test plan
- bun run typecheck
- bun run build
- bun run lint

Made with [Cursor](https://cursor.com)